### PR TITLE
Implement animated dark mode and header toggle

### DIFF
--- a/app/colors/page.tsx
+++ b/app/colors/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from "react"
 import Link from "next/link"
+import { ThemeToggle } from "@/components/theme-toggle"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
@@ -101,11 +102,11 @@ export default function ColorsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="bg-white shadow-sm">
-        <div className="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8 flex justify-between items-center">
+    <div className="min-h-screen">
+      <header className="rounded-3xl border border-white/60 bg-white/70 shadow-lg shadow-slate-200/50 backdrop-blur-md dark:border-white/10 dark:bg-slate-950/55 dark:shadow-slate-950/40">
+        <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-4 sm:px-6 lg:px-8 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center gap-4">
-            <h1 className="text-2xl font-bold text-gray-900">Manage Colors</h1>
+            <h1 className="text-2xl font-bold text-foreground">Manage Colors</h1>
             <Link href="/" passHref>
               <Button variant="outline">Calendar</Button>
             </Link>
@@ -113,10 +114,13 @@ export default function ColorsPage() {
               <Button variant="outline">Manage Statuses</Button>
             </Link>
           </div>
-          <Button onClick={() => setEditingStatus(emptyStatus)}>
-            <Plus className="w-4 h-4 mr-2" />
-            Add New Color
-          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            <ThemeToggle />
+            <Button onClick={() => setEditingStatus(emptyStatus)}>
+              <Plus className="w-4 h-4 mr-2" />
+              Add New Color
+            </Button>
+          </div>
         </div>
       </header>
       <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
@@ -129,7 +133,7 @@ export default function ColorsPage() {
             <CardContent className="p-6">
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
                 {statuses.map((status) => (
-                  <div key={status.id} className="group flex items-center justify-between p-4 border rounded-lg hover:bg-gray-50">
+                  <div key={status.id} className="group flex items-center justify-between rounded-lg border p-4 hover:bg-muted/60">
                     <div className="flex items-center gap-4">
                       <span 
                         className="w-6 h-6 rounded-full"
@@ -137,7 +141,7 @@ export default function ColorsPage() {
                       />
                       <div>
                         <p className="font-semibold">{status.name}</p>
-                        <p className="text-sm text-gray-500">{status.hex}</p>
+                        <p className="text-sm text-muted-foreground">{status.hex}</p>
                       </div>
                     </div>
                     <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,30 +1,29 @@
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 :root {
-  --bg-primary: #f7f6ed;
+  --bg-primary: radial-gradient(circle at top left, #fff7d6 0, #f7f6ed 34%, #eef4ff 100%);
   --text-primary: #222;
   --card-bg: #fff;
   --border-color: #e5e7eb;
+  --font-sans: Montserrat, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 html.dark {
-  --bg-primary: #1a1a1a;
+  --bg-primary: radial-gradient(circle at top left, #172554 0, #0f172a 42%, #020617 100%);
   --text-primary: #f5f5f5;
-  --card-bg: #242424;
-  --border-color: #3a3a3a;
+  --card-bg: #111827;
+  --border-color: #334155;
 }
 
 body {
-  font-family: 'Montserrat', sans-serif;
+  font-family: var(--font-sans);
   background: var(--bg-primary);
   margin: 0;
   min-height: 100vh;
   color: var(--text-primary);
-  transition: background-color 0.3s ease, color 0.3s ease;
+  transition: background 0.5s ease, color 0.5s ease;
 }
 
 html.dark body {
@@ -69,7 +68,7 @@ html.dark .card {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: 'Montserrat', sans-serif;
+  font-family: var(--font-sans);
   font-weight: 700;
   margin: 0;
   color: var(--text-primary);
@@ -159,7 +158,7 @@ h1, h2, h3, h4, h5, h6 {
     @apply border-border transition-colors duration-300;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground antialiased;
   }
   html.dark {
     color-scheme: dark;
@@ -196,4 +195,16 @@ html.dark input, html.dark textarea, html.dark select {
 *:focus {
   outline: none !important;
   box-shadow: none !important;
+}
+
+
+::selection {
+  background: rgba(59, 130, 246, 0.25);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  html,
+  body {
+    transition: background 500ms ease, color 300ms ease;
+  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,7 @@
 import type React from "react"
 import type { Metadata } from "next"
-import { Montserrat } from "next/font/google"
 import "./globals.css"
-
-const montserrat = Montserrat({
-  subsets: ["latin"],
-  weight: ["400", "600", "700"],
-  display: "swap",
-})
+import { ThemeProvider } from "@/components/theme-provider"
 
 export const metadata: Metadata = {
   title: "Uno App",
@@ -25,22 +19,14 @@ export default function RootLayout({
       <head>
         <link rel="icon" href="/favicon.png" />
       </head>
-      <body className={montserrat.className} style={{ transition: "background-color 0.3s ease" }}>
-        <div className="relative h-full p-2 pb-2 cursor-move rounded-sm text-primary bg-input"
-          style={{
-            minHeight: "100vh",
-            background: "var(--bg-primary, #f7f6ed)",
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "flex-start",
-            transition: "background-color 0.3s ease",
-          }}
-        >
-          <main style={{ width: "100%", maxWidth: 1200, margin: "auto", padding: "32px 24px", borderRadius: 24 }}>
-            {children}
-          </main>
-        </div>
+      <body>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem storageKey="uno-theme">
+          <div className="min-h-screen w-full bg-[var(--bg-primary)] text-foreground transition-[background,color] duration-500 ease-out">
+            <main className="mx-auto w-full max-w-[1200px] px-4 py-6 sm:px-6 lg:px-8">
+              {children}
+            </main>
+          </div>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -777,12 +777,12 @@ export default function UnoCalendar() {
     const maxTop = Math.max(...taskPositions.map((pos) => pos.top + pos.height), 200)
 
     return (
-      <div className="border-x border-b border-border bg-gray-800 rounded-lg overflow-hidden dark:bg-stone-800">
+      <div className="overflow-hidden rounded-xl border border-border/70 bg-white/80 shadow-inner transition-colors duration-500 dark:bg-slate-900/80">
         <div className="grid grid-cols-7 divide-x divide-border">
           {weekDays.map((day, index) => (
             <div key={index} className="p-2 text-center">
-              <div className="text-sm font-medium text-secondary-foreground">{formatDayName(day)}</div>
-              <div className="text-lg font-bold text-secondary-foreground">{formatDisplayDate(day)}</div>
+              <div className="text-sm font-medium text-muted-foreground">{formatDayName(day)}</div>
+              <div className="text-lg font-bold text-foreground">{formatDisplayDate(day)}</div>
             </div>
           ))}
         </div>
@@ -815,7 +815,7 @@ export default function UnoCalendar() {
               return (
                 <div
                   key={task.id}
-                  className={`absolute bg-gray-800 dark:bg-stone-800 rounded-lg shadow-md hover:shadow-lg transition-shadow group group/card pointer-events-auto ${isUpdating ? "opacity-75" : ""}`}
+                  className={`absolute rounded-lg bg-white/95 shadow-md ring-1 ring-slate-200/80 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg dark:bg-slate-800/95 dark:ring-white/10 group group/card pointer-events-auto ${isUpdating ? "opacity-75" : ""}`}
                   style={{
                     left: position.left,
                     width: position.width,
@@ -844,7 +844,7 @@ export default function UnoCalendar() {
                   />
                   {/* Card content with padding */}
                   <div
-                    className="relative h-full p-2 pb-2 cursor-move rounded-sm text-foreground bg-gray-800 dark:bg-stone-800"
+                    className="relative h-full cursor-move rounded-lg bg-white/95 p-2 pb-2 text-foreground transition-colors duration-300 dark:bg-slate-800/95"
                     draggable
                     onDragStart={() => handleDragStart(task)}
                   >
@@ -964,7 +964,7 @@ export default function UnoCalendar() {
                           <Button
                             size="sm"
                             variant="ghost"
-                            className="h-6 w-6 p-0 text-gray-600 hover:bg-gray-100 focus:bg-gray-100 active:bg-gray-100 focus:ring-0 focus:outline-none"
+                            className="h-6 w-6 p-0 text-muted-foreground hover:bg-muted focus:bg-muted active:bg-muted focus:ring-0 focus:outline-none"
                             onClick={(e) => {
                               e.stopPropagation()
                               handleEditTask(task)
@@ -1060,12 +1060,9 @@ export default function UnoCalendar() {
   }
 
   return (
-    <div className="min-h-screen" style={{ background: "var(--bg-primary)" }}>
-      <div
-        className="max-w-8xl
-      "
-      >
-        <div className="flex items-center justify-between mb-7 px-2">
+    <div className="min-h-screen">
+      <div className="max-w-8xl">
+        <div className="mb-7 flex flex-col gap-4 rounded-3xl border border-white/60 bg-white/70 px-4 py-3 shadow-lg shadow-slate-200/50 backdrop-blur-md transition-all duration-500 dark:border-white/10 dark:bg-slate-950/55 dark:shadow-slate-950/40 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-2">
             <img
               src="/placeholder-logo.png"
@@ -1073,22 +1070,25 @@ export default function UnoCalendar() {
               style={{ height: "42px", objectFit: "contain", aspectRatio: "auto" }}
             />
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-3">
             <Button
               onClick={() => navigateWeek("up")}
-              className="font-semibold px-3 py-1 text-xs text-foreground bg-transparent hover:bg-muted dark:hover:bg-stone-700"
+              variant="ghost"
+              className="font-semibold px-3 py-1 text-xs text-foreground hover:bg-muted dark:hover:bg-slate-800"
             >
               &lt; Previous Week
             </Button>
             <Button
               onClick={() => setCurrentWeekDate(new Date())}
-              className="font-semibold rounded-sm px-2 py-1 text-xs bg-background text-foreground hover:bg-muted dark:bg-stone-800 dark:hover:bg-stone-700 border border-border"
+              variant="outline"
+              className="font-semibold rounded-full px-3 py-1 text-xs bg-background/80 text-foreground hover:bg-muted dark:bg-slate-900 dark:hover:bg-slate-800"
             >
               Today
             </Button>
             <Button
               onClick={() => navigateWeek("down")}
-              className="font-semibold rounded-sm px-3 py-1 text-xs text-foreground bg-transparent hover:bg-muted dark:hover:bg-stone-700"
+              variant="ghost"
+              className="font-semibold rounded-full px-3 py-1 text-xs text-foreground hover:bg-muted dark:hover:bg-slate-800"
             >
               Next Week &gt;
             </Button>
@@ -1099,7 +1099,8 @@ export default function UnoCalendar() {
               </SelectContent>
             </Select> */}
             <Button
-              className="font-semibold px-4 py-2 text-base bg-background text-foreground text-xs hover:bg-muted dark:bg-stone-800 dark:hover:bg-stone-700 border border-border"
+              variant="outline"
+              className="font-semibold rounded-full px-4 py-2 text-xs bg-background/80 text-foreground hover:bg-muted dark:bg-slate-900 dark:hover:bg-slate-800"
               onClick={handleRecurringTasksClick}
             >
               + Add weekly
@@ -1108,14 +1109,14 @@ export default function UnoCalendar() {
             {/* START UPDATE */}
             {/* END UPDATE */}
             <Button
-              className="font-semibold px-4 py-2 bg-blue-600 text-white text-xs border-none hover:bg-blue-700"
+              className="font-semibold rounded-full px-4 py-2 bg-blue-600 text-white text-xs border-none shadow-md shadow-blue-600/20 hover:-translate-y-0.5 hover:bg-blue-700 hover:shadow-lg"
               onClick={handleNewTaskClick}
             >
               +
             </Button>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button className="font-semibold p-3 bg-blue-600 text-white text-xs border-none hover:bg-blue-700">
+                <Button className="font-semibold rounded-full p-3 bg-blue-600 text-white text-xs border-none shadow-md shadow-blue-600/20 hover:-translate-y-0.5 hover:bg-blue-700 hover:shadow-lg">
                   <Settings className="w-4 h-4" />
                 </Button>
               </DropdownMenuTrigger>
@@ -1133,7 +1134,7 @@ export default function UnoCalendar() {
 
         <div className="space-y-4">
           <Card
-            className="bg-gray-800 dark:bg-stone-800 shadow-sm border-0 rounded-xl overflow-hidden max-w-7xl mx-auto"
+            className="mx-auto max-w-7xl overflow-hidden rounded-2xl border-white/10 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-950 shadow-xl shadow-slate-900/10 dark:from-slate-900 dark:via-slate-950 dark:to-black"
             style={{ paddingLeft: "5%", paddingRight: "5%", paddingTop: 12, marginBottom: 2 }}
           >
             <div className="text-center mb-4 px-2">
@@ -1146,12 +1147,12 @@ export default function UnoCalendar() {
           </Card>
 
           <Card
-            className="bg-background dark:bg-stone-800 shadow-sm border-0 rounded-xl overflow-hidden max-w-7xl mx-auto mt-8"
+            className="mx-auto mt-8 max-w-7xl overflow-hidden rounded-2xl border-white/60 bg-white/75 shadow-xl shadow-slate-200/50 backdrop-blur-md dark:border-white/10 dark:bg-slate-950/70 dark:shadow-slate-950/40"
             style={{ paddingLeft: "5%", paddingRight: "5%", paddingTop: 12, marginBottom: 2 }}
           >
             <div className="text-center mb-4 px-2">
-              <h2 className="text-xl font-bold text-white dark:text-white">{formatWeekRange(nextWeek)}</h2>
-              <p className="text-sm text-white dark:text-gray-300">
+              <h2 className="text-xl font-bold text-foreground">{formatWeekRange(nextWeek)}</h2>
+              <p className="text-sm text-muted-foreground">
                 {nextWeekRecurringCount} recurring task{nextWeekRecurringCount !== 1 ? "s" : ""}
               </p>
             </div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Plus, Edit, Trash2, Loader2, ArrowLeft } from "lucide-react"
 import Link from "next/link"
+import { ThemeToggle } from "@/components/theme-toggle"
 
 interface Status {
   id: number;
@@ -113,15 +114,16 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="p-4 md:p-8 max-w-4xl mx-auto">
-      <header className="flex items-center justify-between mb-8">
+    <div className="mx-auto max-w-4xl p-4 md:p-8">
+      <header className="mb-8 flex flex-col gap-4 rounded-3xl border border-white/60 bg-white/70 p-4 shadow-lg shadow-slate-200/50 backdrop-blur-md dark:border-white/10 dark:bg-slate-950/55 dark:shadow-slate-950/40 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-4">
-            <Link href="/" className="p-2 rounded-full hover:bg-gray-100">
+            <Link href="/" className="p-2 rounded-full hover:bg-muted">
                 <ArrowLeft className="w-6 h-6" />
             </Link>
             <h1 className="text-3xl font-bold">Manage Statuses</h1>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <ThemeToggle />
           <Link href="/colors">
             <Button variant="outline">Manage Colors</Button>
           </Link>
@@ -135,12 +137,12 @@ export default function SettingsPage() {
       <div className="space-y-8">
         {Object.entries(groupedStatuses).map(([category, statusesInCategory]) => (
             <div key={category}>
-                <h2 className="text-xl font-semibold mb-4 text-gray-700">{category}</h2>
+                <h2 className="mb-4 text-xl font-semibold text-foreground/80">{category}</h2>
                 <Card>
                     <CardContent className="p-0">
                     <div className="divide-y">
                         {statusesInCategory.map(status => (
-                        <div key={status.id} className="flex items-center justify-between p-4 hover:bg-gray-50">
+                        <div key={status.id} className="flex items-center justify-between p-4 hover:bg-muted/60">
                             <div className="flex items-center gap-4">
                             <span 
                                 className="w-5 h-5 rounded-full"

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,62 +1,61 @@
 "use client"
 
-import { useState, useEffect } from "react"
-import { Moon, Sun } from "lucide-react"
+import { useEffect, useState } from "react"
+import { Moon, Sparkles, Sun } from "lucide-react"
+import { useTheme } from "next-themes"
 import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 
 export function ThemeToggle() {
-  const [isDark, setIsDark] = useState(false)
+  const { resolvedTheme, setTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
     setMounted(true)
-    const savedTheme = localStorage.getItem("theme") || "light"
-    const isDarkMode = savedTheme === "dark"
-    setIsDark(isDarkMode)
-    applyTheme(isDarkMode)
   }, [])
 
-  const applyTheme = (dark: boolean) => {
-    const html = document.documentElement
-    if (dark) {
-      html.classList.add("dark")
-      html.style.backgroundColor = "#0f0f0f"
-      document.body.style.backgroundColor = "#0f0f0f"
-      localStorage.setItem("theme", "dark")
-    } else {
-      html.classList.remove("dark")
-      html.style.backgroundColor = "#f7f6ed"
-      document.body.style.backgroundColor = "#f7f6ed"
-      localStorage.setItem("theme", "light")
-    }
-  }
-
-  const toggleTheme = () => {
-    const newDarkMode = !isDark
-    setIsDark(newDarkMode)
-    applyTheme(newDarkMode)
-  }
-
-  if (!mounted) return null
+  const isDark = mounted && resolvedTheme === "dark"
 
   return (
     <Button
-      onClick={toggleTheme}
-      className="relative w-10 h-10 p-0 rounded-full bg-white hover:bg-gray-100 text-black border border-gray-200 transition-all duration-300 overflow-hidden"
+      type="button"
+      variant="outline"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className={cn(
+        "group relative h-10 overflow-hidden rounded-full border px-3 shadow-sm transition-all duration-500 ease-out",
+        "bg-white/85 text-slate-900 hover:-translate-y-0.5 hover:bg-white hover:shadow-lg hover:shadow-amber-200/40",
+        "dark:border-white/10 dark:bg-slate-950/80 dark:text-slate-50 dark:hover:bg-slate-900 dark:hover:shadow-sky-950/60",
+      )}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
       title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      disabled={!mounted}
     >
-      <div className="relative w-full h-full flex items-center justify-center">
-        <Sun
-          className={`absolute h-5 w-5 transition-all duration-300 transform ${
-            isDark ? "scale-0 rotate-90 opacity-0" : "scale-100 rotate-0 opacity-100"
-          }`}
-        />
-        <Moon
-          className={`absolute h-5 w-5 transition-all duration-300 transform ${
-            isDark ? "scale-100 rotate-0 opacity-100" : "scale-0 -rotate-90 opacity-0"
-          }`}
-        />
-      </div>
+      <span
+        className={cn(
+          "absolute inset-y-1 left-1 w-8 rounded-full bg-gradient-to-br from-amber-300 via-orange-300 to-rose-300 shadow-sm transition-transform duration-500 ease-out",
+          isDark && "translate-x-[calc(100%+0.5rem)] from-sky-400 via-indigo-400 to-violet-500",
+        )}
+      />
+      <span className="relative z-10 flex items-center gap-2">
+        <span className="relative grid h-6 w-6 place-items-center">
+          <Sun
+            className={cn(
+              "absolute h-4 w-4 text-amber-900 transition-all duration-500 ease-out",
+              isDark ? "-rotate-90 scale-0 opacity-0" : "rotate-0 scale-100 opacity-100",
+            )}
+          />
+          <Moon
+            className={cn(
+              "absolute h-4 w-4 text-white transition-all duration-500 ease-out",
+              isDark ? "rotate-0 scale-100 opacity-100" : "rotate-90 scale-0 opacity-0",
+            )}
+          />
+        </span>
+        <span className="hidden text-xs font-bold uppercase tracking-[0.18em] sm:inline">
+          {isDark ? "Dark" : "Light"}
+        </span>
+        <Sparkles className="hidden h-3.5 w-3.5 opacity-60 transition-transform duration-500 group-hover:rotate-12 sm:block" />
+      </span>
     </Button>
   )
 }

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border shadow-sm bg-[rgba(28,28,28,1)] text-[rgba(25,25,25,1)]",
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
       className
     )}
     {...props}


### PR DESCRIPTION
### Motivation
- Provide a polished light/dark theme with smooth animations and a persistent user preference across sessions. 
- Replace the previous ad-hoc localStorage theme handling with `next-themes` to centralize theme state and improve SSR hydration behavior. 

### Description
- Add a persisted `ThemeProvider` and replace root layout surface with an animated background surface to enable smooth theme transitions (`app/layout.tsx`, `components/theme-provider.tsx`).
- Implement an animated pill-style theme toggle using `next-themes` with icon transitions and accessibility labels (`components/theme-toggle.tsx`).
- Introduce theme-aware design tokens and gradients, improve global transitions and motion handling, and switch to a CSS font fallback to avoid remote font fetch during build (`app/globals.css`).
- Update UI surface and header styles across the calendar, settings, and colors screens to include the toggle and to render nicely in both light and dark modes; make `Card` theme-aware (`app/page.tsx`, `app/settings/page.tsx`, `app/colors/page.tsx`, `components/ui/card.tsx`).

### Testing
- Ran `git diff --check` with no issues reported. ✅
- Ran TypeScript checks with `pnpm exec tsc --noEmit` after cleanup and there were no type errors. ✅
- Built the app with dummy Supabase env vars using `NEXT_PUBLIC_SUPABASE_URL=... NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy pnpm build` and the production build completed successfully. ✅
- Attempted `pnpm lint`, which failed because the repository does not include the required ESLint flat config for ESLint 10. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1d72c2a0832b802ea625a0326843)